### PR TITLE
PIL max pixels

### DIFF
--- a/tms2geotiff.py
+++ b/tms2geotiff.py
@@ -19,6 +19,8 @@ except ImportError:
 
 EARTH_EQUATORIAL_RADIUS = 6378137.0
 
+Image.MAX_IMAGE_PIXELS = None
+
 DEFAULT_TMS = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png'
 
 gdal.UseExceptions()


### PR DESCRIPTION
Working with larger areas and smaller zoom levels can result in an error from PIL: PIL.Image.DecompressionBombError : Image size (x pixels) exceeds limit of 178956970 pixels, could be decompression bomb DOS attack.
That's excepted, regular images arent supposed to have so many pixels, but when working with GeoTIFF, that's completely normal.

Anyways, to make the script work with larger areas, a single line of code was needed. Tested it out by myself with a resulting size of 933120000 pixels and it worked well.